### PR TITLE
chore(contributing): responsible disclosure

### DIFF
--- a/static/CONTRIBUTING.md
+++ b/static/CONTRIBUTING.md
@@ -11,6 +11,8 @@ changes, and helping you finalize your pull requests.
 
 ## Using the issue tracker
 
+First things first: **Do NOT report security vulnerablities in public issues!** Please disclose responsibly by letting [the Hoodie team](mailto:team@thehoodiefirm.com?subject=Security) know upfront. We will assess the issue as soon as possible on a best-effort basis and will give you an estimate for when we have a fix and release available for an eventual public disclosure.
+
 The issue tracker is the preferred channel for [bug reports](#bugs),
 [features requests](#features) and [submitting pull
 requests](#pull-requests), but please respect the following restrictions:


### PR DESCRIPTION
Ask to not use the issue tracker to disclose security problems
