### PR TITLE
[docs] Change references to hoodie.js to hoodie

### DIFF
--- a/static/CONTRIBUTING.md
+++ b/static/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Hoodie.js
+# Contributing to Hoodie
 
 Please take a moment to review this document in order to make the contribution
 process easy and effective for everyone involved.
@@ -18,7 +18,7 @@ The issue tracker is the preferred channel for [bug reports](#bugs),
 requests](#pull-requests), but please respect the following restrictions:
 
 * Please **do not** use the issue tracker for personal support requests. Use
-  [#Hoodie.js](http://webchat.freenode.net/?channels=hoodie) on Freenode.
+  [#Hoodie](http://webchat.freenode.net/?channels=hoodie) on Freenode.
 
 * Please **do not** derail or troll issues. Keep the discussion on topic and
   respect the opinions of others.


### PR DESCRIPTION
The IRC channel change makes sense, the title change, to me, makes sense because this file will be synced to other projects that aren't hoodie.js.